### PR TITLE
Consumer gRPC Server Setup (Issue #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ build/
 *.js.map
 *.d.ts
 
+# Proto compiled output
+proto/*.js
+proto/*.d.ts
+
 # But keep config files
 !*.config.js
 !vite.config.ts

--- a/consumer/src/grpc-server.ts
+++ b/consumer/src/grpc-server.ts
@@ -1,0 +1,137 @@
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import * as path from 'path';
+import * as fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { VideoChunk, UploadResponse, QueueStatusResponse } from '../../proto/types';
+
+const PROTO_PATH = path.join(__dirname, '../../proto/video_upload.proto');
+
+/**
+ * Handle streaming video upload from producer
+ */
+function uploadVideo(call: grpc.ServerReadableStream<VideoChunk, UploadResponse>, callback: grpc.sendUnaryData<UploadResponse>) {
+  const chunks: Buffer[] = [];
+  let filename = '';
+  let producerId = 0;
+
+  call.on('data', (chunk: VideoChunk) => {
+    filename = chunk.filename;
+    producerId = chunk.producer_id;
+    chunks.push(chunk.data);
+
+    console.log(`[Producer ${producerId}] Received chunk ${chunk.chunk_number} for ${filename}`);
+
+    if (chunk.is_last) {
+      console.log(`[Producer ${producerId}] Received last chunk for ${filename}, reassembling...`);
+    }
+  });
+
+  call.on('end', () => {
+    try {
+      // Reassemble video from chunks
+      const completeVideo = Buffer.concat(chunks);
+
+      // Save to uploaded-videos directory
+      const uploadDir = process.env.UPLOAD_DIR || './uploaded-videos';
+      if (!fs.existsSync(uploadDir)) {
+        fs.mkdirSync(uploadDir, { recursive: true });
+      }
+
+      const videoId = uuidv4();
+      const timestamp = new Date().toISOString().replace(/:/g, '-').split('.')[0];
+      const savedFilename = `${timestamp}_${filename}`;
+      const filepath = path.join(uploadDir, savedFilename);
+
+      fs.writeFileSync(filepath, completeVideo);
+
+      console.log(`[Producer ${producerId}] Successfully saved ${filename} as ${savedFilename} (${completeVideo.length} bytes)`);
+
+      const response: UploadResponse = {
+        success: true,
+        message: `Video uploaded successfully`,
+        video_id: videoId,
+        queue_full: false // Placeholder for Issue #10
+      };
+
+      callback(null, response);
+    } catch (error) {
+      console.error(`[ERROR] Error saving video:`, error);
+
+      const errorResponse: UploadResponse = {
+        success: false,
+        message: `Failed to save video: ${error}`,
+        video_id: '',
+        queue_full: false
+      };
+
+      callback(null, errorResponse);
+    }
+  });
+
+  call.on('error', (error) => {
+    console.error(`[ERROR] Error during upload:`, error);
+  });
+}
+
+/**
+ * Handle queue status request
+ * Note: Returns placeholder values until Issue #10 (Bounded Queue) is implemented
+ */
+function checkQueueStatus(call: grpc.ServerUnaryCall<any, QueueStatusResponse>, callback: grpc.sendUnaryData<QueueStatusResponse>) {
+  // Placeholder implementation for Issue #10
+  const maxSize = parseInt(process.env.QUEUE_MAX_SIZE || '10', 10);
+
+  const response: QueueStatusResponse = {
+    current_size: 0,
+    max_size: maxSize,
+    is_full: false,
+    utilization: 0.0
+  };
+
+  callback(null, response);
+}
+
+/**
+ * Start the gRPC server
+ */
+export function startGrpcServer(): void {
+  // Load proto file
+  const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
+
+  const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any;
+  const videoUploadProto = protoDescriptor.video_upload;
+
+  // Create server
+  const server = new grpc.Server();
+
+  // Add service implementation
+  server.addService(videoUploadProto.VideoUploadService.service, {
+    UploadVideo: uploadVideo,
+    CheckQueueStatus: checkQueueStatus
+  });
+
+  // Bind and start server
+  const port = process.env.GRPC_PORT || '50051';
+  const bindAddress = `0.0.0.0:${port}`;
+
+  server.bindAsync(
+    bindAddress,
+    grpc.ServerCredentials.createInsecure(),
+    (error, port) => {
+      if (error) {
+        console.error(`[ERROR] Failed to start gRPC server:`, error);
+        return;
+      }
+
+      console.log(`gRPC server running on port ${port}`);
+      console.log(`Upload directory: ${process.env.UPLOAD_DIR || './uploaded-videos'}`);
+    }
+  );
+}

--- a/consumer/src/index.ts
+++ b/consumer/src/index.ts
@@ -1,0 +1,12 @@
+import dotenv from 'dotenv';
+import { startGrpcServer } from './grpc-server';
+
+// Load environment variables
+dotenv.config();
+
+console.log('='.repeat(50));
+console.log('Media Upload Consumer Service');
+console.log('='.repeat(50));
+
+// Start gRPC server
+startGrpcServer();

--- a/consumer/tsconfig.json
+++ b/consumer/tsconfig.json
@@ -2,17 +2,26 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": [
+      "ES2020"
+    ],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "../proto/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/producer/src/grpc-client.ts
+++ b/producer/src/grpc-client.ts
@@ -1,7 +1,7 @@
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import path from 'path';
-import { UploadResponse, QueueStatusResponse, VideoChunk } from './types';
+import { UploadResponse, QueueStatusResponse, VideoChunk } from '../../proto/types';
 
 const PROTO_PATH = path.resolve(__dirname, '../../proto/video_upload.proto');
 

--- a/producer/tsconfig.json
+++ b/producer/tsconfig.json
@@ -2,17 +2,26 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": [
+      "ES2020"
+    ],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "../proto/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/proto/types.ts
+++ b/proto/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared TypeScript types for gRPC communication
+ * These types correspond to the protobuf definitions in video_upload.proto
+ */
+
 export interface VideoChunk {
   filename: string;
   data: Buffer;
@@ -14,7 +19,9 @@ export interface UploadResponse {
   queue_full: boolean;
 }
 
-export interface QueueStatusRequest { }
+export interface QueueStatusRequest {
+  // Empty for now
+}
 
 export interface QueueStatusResponse {
   current_size: number;


### PR DESCRIPTION
## Summary
Implements the foundational gRPC server infrastructure for the Consumer service.

## Changes
- Created consumer/src/grpc-server.ts with UploadVideo and CheckQueueStatus handlers
- Created consumer/src/index.ts as entry point
- Added shared proto/types.ts for type definitions used by both producer and consumer
- Updated tsconfig.json for both services to support shared types
- Server listens on port 50051 and handles concurrent video uploads

## Testing
- Build succeeds for both consumer and producer
- Server starts successfully on port 50051
- No errors or warnings

## Notes
- Queue integration will be added in Issue #10
- CheckQueueStatus returns placeholder values until bounded queue is implemented

Closes #9